### PR TITLE
Fixed crash when the reponse object is null

### DIFF
--- a/web.js
+++ b/web.js
@@ -473,7 +473,7 @@ function defaultresponder(req,res,handlerspec,err,obj) {
       })
     }
   }
-  else if( _.isUndefined(obj) ) {
+  else if( _.isUndefined(obj) || _.isNull(obj) ) {
     outobj = ''
   }
   else {


### PR DESCRIPTION
This fixes a crash when obj is null, which happens pretty often when obj is the result of a mongo query.