### PR TITLE
Don't delete headers when result is an array.

### DIFF
--- a/test/test-client.js
+++ b/test/test-client.js
@@ -72,6 +72,15 @@ needle.put(
     assert.deepEqual( res.body, { d1: 'e1f1', d2: 'e2' } )
   })
 
+url = 'http://localhost:3001/t0/c3',
+console.log('GET '+url)
+needle.get(url,function(err,res){
+  assert.ok( !err )
+  assert.deepEqual( res.body, [{a:1}, {b:2}] )
+  assert.ok( res.headers );
+  assert.equal( res.headers.foo, 'bar' );
+})
+
 var url = 'http://localhost:3001/t0/e0'
 console.log('GET '+url)
 needle.get(url,function(err,res){

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -32,6 +32,12 @@ seneca.use( function p0() {
     done(null,{d1:src.d1+'f1',d2:src.d2})
   })
 
+  this.add('role:api,cmd:c3',function(args,done){
+    var a = [{a:1}, {b:2}];
+    a.http$ = { headers: { Foo: 'bar' } };
+    done(null, a);
+  })
+
   this.add('role:api,cmd:e0',function(args,done){
     done(new Error('e0'))
   })

--- a/web.js
+++ b/web.js
@@ -417,6 +417,8 @@ function make_defaultresponder( spec, routespec, methodspec ) {
     }
     else {
       outobj = _.clone( obj )
+      // Ensure metadata is cloned when obj is an array.
+      _.assign(outobj, _.pick(obj, ['http$', 'redirect$', 'httpstatus$']));
     }
 
     var http = outobj.http$


### PR DESCRIPTION
Fixes not being able to set headers for array results.  They will be `_.clone`d which causes them to lose metadata like `http$`.  

Semi-related to: https://github.com/rjrodger/seneca-web/pull/16 (this PR augments the tests from there).